### PR TITLE
SSL環境下で非SSL対応サービスによる警告を修正する

### DIFF
--- a/modules/services.php
+++ b/modules/services.php
@@ -399,7 +399,7 @@ class WpSocialBookmarkingLight
                                     .'</fb:like>');
         }
         else{
-            return $this->link_raw('<iframe src="http://www.facebook.com/plugins/like.php?href='.$this->encode_url
+            return $this->link_raw('<iframe src="//www.facebook.com/plugins/like.php?href='.$this->encode_url
                     .'&amp;layout='.$layout
                     .'&amp;show_faces=false'
                     .'&amp;width='.$width


### PR DESCRIPTION
utahtaさん

こんにちは。

WordPressをSSLで閲覧した際、iframeやscriptなどでSSL非対応のサイトのリソースを読み込んだ際に、警告が表示されてしまいます。

それを修正するpull requestです。
マージよろしくお願いいたします。
