### PR TITLE
Remove is_comments_popup()

### DIFF
--- a/modules/content.php
+++ b/modules/content.php
@@ -123,7 +123,7 @@ function wp_social_bookmarking_light_wp_head()
  */
 function wp_social_bookmarking_light_is_enabled()
 {
-    if (is_feed() || is_404() || is_robots() || is_comments_popup() || (function_exists( 'is_ktai' ) && is_ktai())) {
+    if (is_feed() || is_404() || is_robots() || (function_exists( 'is_ktai' ) && is_ktai())) {
         return false;
     }
 


### PR DESCRIPTION
Noticeエラー修正のため、 `is_comments_popup()` を削除しました。WordPressバージョン4.5からこの判定は非推奨になっています。

Notice: is_comments_popup is deprecated since version 4.5 with no alternative available. 
https://developer.wordpress.org/reference/functions/is_comments_popup/