### PR TITLE
Update Facebook SDK Version

### DIFF
--- a/modules/content.php
+++ b/modules/content.php
@@ -100,7 +100,7 @@ function wp_social_bookmarking_light_wp_head()
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
   js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/<?php echo $locale ?>/sdk.js#xfbml=1&version=v2.0";
+  js.src = "//connect.facebook.net/<?php echo $locale ?>/sdk.js#xfbml=1&version=v2.7";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
 <?php


### PR DESCRIPTION
2016年8月8日で Facebook Graph API v2.0 の期限が切れるので、v2.０から v2.7に書き換えました。
ご確認の程、よろしくお願いいたします。

https://developers.facebook.com/docs/apps/changelog?locale=ja_JP