### PR TITLE
Fix WP_SOCIAL_BOOKMARKING_LIGHT_DIR for docker based PaaS

### DIFF
--- a/wp-social-bookmarking-light.php
+++ b/wp-social-bookmarking-light.php
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 // settings
-define( "WP_SOCIAL_BOOKMARKING_LIGHT_DIR", WP_PLUGIN_DIR."/wp-social-bookmarking-light" );
+define( "WP_SOCIAL_BOOKMARKING_LIGHT_DIR", dirname( __FILE__ ) );
 define( "WP_SOCIAL_BOOKMARKING_LIGHT_URL", WP_PLUGIN_URL."/wp-social-bookmarking-light" );
 define( "WP_SOCIAL_BOOKMARKING_LIGHT_IMAGES_URL", WP_SOCIAL_BOOKMARKING_LIGHT_URL."/images" );
 define( "WP_SOCIAL_BOOKMARKING_LIGHT_DOMAIN", "wp-social-bookmarking-light" );


### PR DESCRIPTION
Google Cloud Platformで構築したWordpressに導入したところ、以下のようなエラーが出てプラグインが有効化できませんでした。

```
Warning: require_once(/base/data/home/apps/s~my-project/20170105t154239.398250465994381890/wordpress/wp-content/plugins/wp-social-bookmarking-light/modules/options.php): failed to open stream: No such file or directory in /base/data/home/apps/s~my-project/20170105t154239.398250465994381890/wordpress/wp-content/plugins/WP-Social-Bookmarking-Light/wp-social-bookmarking-light.php on line 43
Fatal error: require_once(): Failed opening required '/base/data/home/apps/s~my-project/20170105t154239.398250465994381890/wordpress/wp-content/plugins/wp-social-bookmarking-light/modules/options.php' (include_path='.;/base/data/home/apps/s~my-project/20170105t154239.398250465994381890/;/base/data/home/runtimes/php/sdk') in /base/data/home/apps/s~my-project/20170105t154239.398250465994381890/wordpress/wp-content/plugins/WP-Social-Bookmarking-Light/wp-social-bookmarking-light.php on line 43
```

他の動作しているプラグインを参考に、`__FILE__`を元に参照したところ、有効化できることを確認いたしましたので、プルリクエストを作成させていただきました。
ご確認いただけますと幸いです。