### PR TITLE
https対応(WP_PLUGIN_URLをplugins_url()に変更)

### DIFF
--- a/modules/services.php
+++ b/modules/services.php
@@ -511,7 +511,7 @@ class WpSocialBookmarkingLight
                                  ." data-url='{$this->url}'"
                                  ." data-button='{$data_button}'"
                                  ." data-key='{$data_key}'>Check</a>"
-                                 .'<script type="text/javascript" src="https://static.mixi.jp/js/share.js"></script>' );
+                                 .'<script type="text/javascript" src="//static.mixi.jp/js/share.js"></script>' );
     }
     
     /**

--- a/modules/services.php
+++ b/modules/services.php
@@ -511,7 +511,7 @@ class WpSocialBookmarkingLight
                                  ." data-url='{$this->url}'"
                                  ." data-button='{$data_button}'"
                                  ." data-key='{$data_key}'>Check</a>"
-                                 .'<script type="text/javascript" src="http://static.mixi.jp/js/share.js"></script>' );
+                                 .'<script type="text/javascript" src="https://static.mixi.jp/js/share.js"></script>' );
     }
     
     /**

--- a/wp-social-bookmarking-light.php
+++ b/wp-social-bookmarking-light.php
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // settings
 define( "WP_SOCIAL_BOOKMARKING_LIGHT_DIR", dirname( __FILE__ ) );
-define( "WP_SOCIAL_BOOKMARKING_LIGHT_URL", WP_PLUGIN_URL."/wp-social-bookmarking-light" );
+define( "WP_SOCIAL_BOOKMARKING_LIGHT_URL", plugins_url()."/wp-social-bookmarking-light" );
 define( "WP_SOCIAL_BOOKMARKING_LIGHT_IMAGES_URL", WP_SOCIAL_BOOKMARKING_LIGHT_URL."/images" );
 define( "WP_SOCIAL_BOOKMARKING_LIGHT_DOMAIN", "wp-social-bookmarking-light" );
 


### PR DESCRIPTION
httpsのサイトでJavaScriptや画像ファイルの読み込みがブロックされることに対応。

WP_PLUGIN_URL を plugins_url() に変更することで概ね対応できたが、
うちでは、twitter/google_plus_one/mixi/facebook/yahoo/livedoor/friendfeed/hatena_buttonを使っていて、mixiでだけ、追加で問題が発生していたため、個別で対応。
使用していない他のサービスについては確認していない。
