### PR TITLE
PHP7においてDeprecated

### DIFF
--- a/modules/content.php
+++ b/modules/content.php
@@ -123,7 +123,7 @@ function wp_social_bookmarking_light_wp_head()
  */
 function wp_social_bookmarking_light_is_enabled()
 {
-    if (is_feed() || is_404() || is_robots() || is_comments_popup() || (function_exists( 'is_ktai' ) && is_ktai())) {
+    if (is_feed() || is_404() || is_robots() || (function_exists( 'is_ktai' ) && is_ktai())) {
         return false;
     }
 

--- a/modules/services.php
+++ b/modules/services.php
@@ -28,7 +28,7 @@ class WpSocialBookmarkingLight
     var $encode_title;
     var $encode_blogname;
     
-    function WpSocialBookmarkingLight( $url, $title, $blogname )
+    function __construct( $url, $title, $blogname )
     {
         $title = $this->to_utf8( $title );
         $this->blogname = $this->to_utf8( $blogname );


### PR DESCRIPTION
PHP7の環境においてWP_DEBUGをtrueにしていると以下のメッセージが表示されます。

Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; WpSocialBookmarkingLight has a deprecated constructor in /xxxxxxxxx/wp/wp-content/plugins/wp-social-bookmarking-light/modules/services.php on line 23

この時、ログイン画面でCannot modify header informationのWarningが出て、ログインもできなくなります。WP_DEBUGをfalseにすれば回避できるのですが、コンストラクタの名前の変更で対応できましたのでご確認よろしくお願いします。
