### PR TITLE
AMPページで表示しない

### DIFF
--- a/modules/content.php
+++ b/modules/content.php
@@ -139,6 +139,11 @@ function wp_social_bookmarking_light_is_enabled()
     if (in_array('get_the_excerpt', (array)$wp_current_filter)) {
         return false;
     }
+
+    if (get_query_var('amp', false) !== false) {
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
AMPページでSNSボタンを表示した場合、AMPエラーが発生するため
AMPページでは表示しないようにしました。

もしAMP対応する予定があるのであれば必要ありませんが
AMP対応予定が無い場合は、マージして頂けると助かります。

ご検討宜しくお願い致します。
